### PR TITLE
Make Mu a normal compile-time dependency

### DIFF
--- a/project/ProjectPlugin.scala
+++ b/project/ProjectPlugin.scala
@@ -36,7 +36,7 @@ object ProjectPlugin extends AutoPlugin {
 
     lazy val srcGenSettings: Seq[Def.Setting[_]] = Seq(
       libraryDependencies ++= Seq(
-        "io.higherkindness"          %% "mu-rpc-channel"           % V.mu % Provided,
+        "io.higherkindness"          %% "mu-rpc-channel"           % V.mu,
         "com.github.julien-truffaut" %% "monocle-core"             % V.monocle,
         "io.higherkindness"          %% "skeuomorph"               % V.skeuomorph,
         "com.julianpeeters"          %% "avrohugger-core"          % V.avrohugger,


### PR DESCRIPTION
I just tried publishing the plugin locally and using it in a project, and the `muSrcGen` task threw a ClassNotFoundException.

Mu will be on the classpath of an end-user's Mu application, but it won't be on the classpath of the sbt plugin. So I don't think a "provided" dependency makes sense here.

Confirmed locally that making it a normal dependency fixes the issue.

At first I was worried we might have a circular dependency between Mu and the plugin, but that's not true. We just need to release Mu first, bump the Mu dependency version in the plugin, then release the plugin.