### PR TITLE
Updates to mu-scala 0.22.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ ThisBuild / scalaVersion := "2.12.11"
 ThisBuild / organization := "io.higherkindness"
 ThisBuild / githubOrganization := "47degrees"
 
-addCommandAlias("ci-test", "scalafmtCheckAll; scalafmtSbtCheck; test; scripted")
+addCommandAlias("ci-test", "scalafmtCheckAll; scalafmtSbtCheck; test; publishLocal; scripted")
 addCommandAlias("ci-docs", "project-docs/mdoc; headerCreateAll")
 
 lazy val core = project

--- a/core/src/main/scala/higherkindness/mu/rpc/srcgen/FileUtil.scala
+++ b/core/src/main/scala/higherkindness/mu/rpc/srcgen/FileUtil.scala
@@ -1,0 +1,19 @@
+package higherkindness.mu.rpc.srcgen
+
+import java.io._
+
+object FileUtil {
+
+  implicit class FileOps(val file: File) extends AnyVal {
+
+    def write(lines: Seq[String]): Unit = {
+      val writer = new PrintWriter(file)
+      try lines.foreach(writer.println)
+      finally writer.close()
+    }
+
+    def write(line: String): Unit = write(Seq(line))
+
+  }
+
+}

--- a/core/src/main/scala/higherkindness/mu/rpc/srcgen/GeneratorApplication.scala
+++ b/core/src/main/scala/higherkindness/mu/rpc/srcgen/GeneratorApplication.scala
@@ -18,7 +18,7 @@ package higherkindness.mu.rpc.srcgen
 
 import java.io.File
 
-import higherkindness.mu.rpc.internal.util.FileUtil._
+import FileUtil._
 import higherkindness.mu.rpc.srcgen.Model.{IdlType, SerializationType}
 import org.log4s.getLogger
 

--- a/plugin/src/sbt-test/sbt-mu-srcgen/avroWithSchema/build.sbt
+++ b/plugin/src/sbt-test/sbt-mu-srcgen/avroWithSchema/build.sbt
@@ -1,7 +1,7 @@
 version := sys.props("version")
 
 libraryDependencies ++= Seq(
-  "io.higherkindness" %% "mu-rpc-channel" % sys.props("version")
+  "io.higherkindness" %% "mu-rpc-service" % sys.props("mu")
 )
 
 addCompilerPlugin("org.scalamacros" % "paradise" % "2.1.1" cross CrossVersion.patch)

--- a/plugin/src/sbt-test/sbt-mu-srcgen/basic/build.sbt
+++ b/plugin/src/sbt-test/sbt-mu-srcgen/basic/build.sbt
@@ -1,5 +1,5 @@
 version := sys.props("version")
 
 libraryDependencies ++= Seq(
-  "io.higherkindness" %% "mu-rpc-server" % sys.props("version")
+  "io.higherkindness" %% "mu-rpc-server" % sys.props("mu")
 )

--- a/plugin/src/sbt-test/sbt-mu-srcgen/gzipCompression/build.sbt
+++ b/plugin/src/sbt-test/sbt-mu-srcgen/gzipCompression/build.sbt
@@ -1,7 +1,7 @@
 version := sys.props("version")
 
 libraryDependencies ++= Seq(
-  "io.higherkindness" %% "mu-rpc-channel" % sys.props("version")
+  "io.higherkindness" %% "mu-rpc-service" % sys.props("mu")
 )
 
 addCompilerPlugin("org.scalamacros" % "paradise" % "2.1.1" cross CrossVersion.patch)

--- a/plugin/src/sbt-test/sbt-mu-srcgen/idiomaticEndpoints/build.sbt
+++ b/plugin/src/sbt-test/sbt-mu-srcgen/idiomaticEndpoints/build.sbt
@@ -1,7 +1,7 @@
 version := sys.props("version")
 
 libraryDependencies ++= Seq(
-  "io.higherkindness" %% "mu-rpc-channel" % sys.props("version")
+  "io.higherkindness" %% "mu-rpc-service" % sys.props("mu")
 )
 
 addCompilerPlugin("org.scalamacros" % "paradise" % "2.1.1" cross CrossVersion.patch)

--- a/plugin/src/sbt-test/sbt-mu-srcgen/importMarshallers/build.sbt
+++ b/plugin/src/sbt-test/sbt-mu-srcgen/importMarshallers/build.sbt
@@ -1,8 +1,8 @@
 version := sys.props("version")
 
 libraryDependencies ++= Seq(
-  "io.higherkindness" %% "mu-rpc-channel" % sys.props("version"),
-  "io.higherkindness" %% "mu-rpc-marshallers-jodatime" % sys.props("version")
+  "io.higherkindness" %% "mu-rpc-service" % sys.props("mu"),
+  "io.higherkindness" %% "mu-rpc-marshallers-jodatime" % sys.props("mu")
 )
 
 addCompilerPlugin("org.scalamacros" % "paradise" % "2.1.1" cross CrossVersion.patch)

--- a/plugin/src/sbt-test/sbt-mu-srcgen/srcGenFromDirs/build.sbt
+++ b/plugin/src/sbt-test/sbt-mu-srcgen/srcGenFromDirs/build.sbt
@@ -12,6 +12,6 @@ lazy val root = project
     ),
     muSrcGenTargetDir := (Compile / sourceManaged).value / "generated_from_avro",
     libraryDependencies ++= Seq(
-      "io.higherkindness" %% "mu-rpc-channel" % sys.props("version")
+      "io.higherkindness" %% "mu-rpc-service" % sys.props("mu")
     )
   ))

--- a/plugin/src/sbt-test/sbt-mu-srcgen/srcGenFromJars/build.sbt
+++ b/plugin/src/sbt-test/sbt-mu-srcgen/srcGenFromJars/build.sbt
@@ -15,7 +15,7 @@ lazy val domain = project
     muSrcGenSourceDirs := Seq((Compile / resourceDirectory).value),
     muSrcGenTargetDir := (Compile / sourceManaged).value / "generated_from_avro",
     libraryDependencies ++= Seq(
-      "io.higherkindness" %% "mu-rpc-channel" % sys.props("version")
+      "io.higherkindness" %% "mu-rpc-service" % sys.props("mu")
     )
   ))
 

--- a/plugin/src/sbt-test/sbt-mu-srcgen/srcProtoGenFromDirs/build.sbt
+++ b/plugin/src/sbt-test/sbt-mu-srcgen/srcProtoGenFromDirs/build.sbt
@@ -7,7 +7,7 @@ lazy val root = project
     muSrcGenTargetDir := (Compile / sourceManaged).value / "compiled_proto",
     addCompilerPlugin("org.scalamacros" % "paradise" % "2.1.1" cross CrossVersion.patch),
     libraryDependencies ++= Seq(
-        "io.higherkindness"    %% "mu-rpc-channel" % sys.props("version"),
-        "io.higherkindness"    %% "mu-rpc-internal-fs2" % sys.props("version")
+        "io.higherkindness"    %% "mu-rpc-service" % sys.props("mu"),
+        "io.higherkindness"    %% "mu-rpc-fs2" % sys.props("mu")
     )
   )

--- a/plugin/src/sbt-test/sbt-mu-srcgen/srcProtoGenMonix/build.sbt
+++ b/plugin/src/sbt-test/sbt-mu-srcgen/srcProtoGenMonix/build.sbt
@@ -9,7 +9,7 @@ lazy val root = project
     muSrcGenStreamingImplementation := MonixObservable,
     addCompilerPlugin("org.scalamacros" % "paradise" % "2.1.1" cross CrossVersion.patch),
     libraryDependencies ++= Seq(
-        "io.higherkindness"    %% "mu-rpc-channel" % sys.props("version"),
-        "io.higherkindness"    %% "mu-rpc-internal-monix" % sys.props("version")
+        "io.higherkindness"    %% "mu-rpc-service" % sys.props("mu"),
+        "io.higherkindness"    %% "mu-rpc-monix" % sys.props("mu")
     )
   )

--- a/project/ProjectPlugin.scala
+++ b/project/ProjectPlugin.scala
@@ -18,7 +18,7 @@ object ProjectPlugin extends AutoPlugin {
       val avrohugger: String          = "1.0.0-RC22"
       val circe: String               = "0.13.0"
       val monocle: String             = "2.0.4"
-      val mu                          = "0.21.3"
+      val mu                          = "0.22.0"
       val scalacheck: String          = "1.14.3"
       val scalatest: String           = "3.1.1"
       val scalatestplusScheck: String = "3.1.0.0-RC2"
@@ -28,7 +28,7 @@ object ProjectPlugin extends AutoPlugin {
 
     lazy val srcGenSettings: Seq[Def.Setting[_]] = Seq(
       libraryDependencies ++= Seq(
-        "io.higherkindness"          %% "mu-rpc-channel"           % V.mu,
+        "io.higherkindness"          %% "mu-rpc-service"           % V.mu,
         "com.github.julien-truffaut" %% "monocle-core"             % V.monocle,
         "io.higherkindness"          %% "skeuomorph"               % V.skeuomorph,
         "com.julianpeeters"          %% "avrohugger-core"          % V.avrohugger,
@@ -45,7 +45,8 @@ object ProjectPlugin extends AutoPlugin {
       scriptedLaunchOpts ++= Seq(
         "-Xmx2048M",
         "-XX:ReservedCodeCacheSize=256m",
-        "-Dversion=" + V.mu,
+        "-Dmu=" + V.mu,
+        "-Dversion=" + version.value,
         // See https://github.com/sbt/sbt/issues/3469#issuecomment-521326813
         s"-Dsbt.boot.directory=${file(sys.props("user.home")) / ".sbt" / "boot"}"
       )

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.3.9
+sbt.version = 1.3.10


### PR DESCRIPTION
This PR updates to the latest version of mu-scala, [v0.22.0](https://github.com/higherkindness/mu-scala/releases/tag/v0.22.0).