### PR TITLE
Make the plugin manual

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ addSbtPlugin("io.higherkindness" % "sbt-mu-srcgen" % "$version") // see badge in
 ```
 ### NOTE
 
-For any users using version `0.22.3` and below, the `SrcGenPlugin` is enabled on every module by default.  However, for everyone using 
+For any users using version `0.22.x` and below, the `SrcGenPlugin` is enabled on every module by default.  However, for everyone using 
 version `0.23.3` and beyond (the latest version), you'll need to manually enable the plugin for any module for which you want to 
 auto-generate [mu-scala] code, like such:
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ addSbtPlugin("io.higherkindness" % "sbt-mu-srcgen" % "$version") // see badge in
 ### NOTE
 
 For any users using version `0.22.x` and below, the `SrcGenPlugin` is enabled on every module by default.  However, for everyone using 
-version `0.23.3` and beyond (the latest version), you'll need to manually enable the plugin for any module for which you want to 
+version `0.23.x` and beyond (the latest version), you'll need to manually enable the plugin for any module for which you want to 
 auto-generate [mu-scala] code, like such:
 
 ```scala

--- a/README.md
+++ b/README.md
@@ -12,8 +12,20 @@
 For installing this plugin, add the following line to your `plugins.sbt` file:
 
 ```scala
-addSbtPlugin("io.higherkindness" % "sbt-mu-srcgen" % "0.22.3")
+addSbtPlugin("io.higherkindness" % "sbt-mu-srcgen" % "$version") // see badge in the project for the latest version
 ```
+### NOTE
+
+For any users using version `0.22.3` and below, the `SrcGenPlugin` is enabled on every module by default.  However, for everyone using 
+version `0.23.3` and beyond (the latest version), you'll need to manually enable the plugin for any module for which you want to 
+auto-generate [mu-scala] code, like such:
+
+```scala
+.enablePlugins(SrcGenPlugin)
+```
+
+**this is a breaking change between the versions**, so be sure to make sure that you're choosing your modules to enable source generation
+intentionally if you want to upgrade this library.
 
 The full documentation is available at the [mu](https://higherkindness.io/mu-scala/guides/generate-sources-from-idl) site.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,8 +12,20 @@
 For installing this plugin, add the following line to your `plugins.sbt` file:
 
 ```scala
-addSbtPlugin("io.higherkindness" % "sbt-mu-srcgen" % "@VERSION@")
+addSbtPlugin("io.higherkindness" % "sbt-mu-srcgen" % "$version") // see badge in the project for the latest version
 ```
+### NOTE
+
+For any users using version `0.22.x` and below, the `SrcGenPlugin` is enabled on every module by default.  However, for everyone using 
+version `0.23.x` and beyond (the latest version), you'll need to manually enable the plugin for any module for which you want to 
+auto-generate [mu-scala] code, like such:
+
+```scala
+.enablePlugins(SrcGenPlugin)
+```
+
+**this is a breaking change between the versions**, so be sure to make sure that you're choosing your modules to enable source generation
+intentionally if you want to upgrade this library.
 
 
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,6 +15,8 @@ For installing this plugin, add the following line to your `plugins.sbt` file:
 addSbtPlugin("io.higherkindness" % "sbt-mu-srcgen" % "@VERSION@")
 ```
 
+
+
 The full documentation is available at the [mu](https://higherkindness.io/mu-scala/guides/generate-sources-from-idl) site.
 
 [RPC]: https://en.wikipedia.org/wiki/Remote_procedure_call

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,7 +12,7 @@
 For installing this plugin, add the following line to your `plugins.sbt` file:
 
 ```scala
-addSbtPlugin("io.higherkindness" % "sbt-mu-srcgen" % "$version") // see badge in the project for the latest version
+addSbtPlugin("io.higherkindness" % "sbt-mu-srcgen" % "@VERSION@")
 ```
 ### NOTE
 

--- a/plugin/src/main/scala/higherkindness/mu/rpc/srcgen/SrcGenPlugin.scala
+++ b/plugin/src/main/scala/higherkindness/mu/rpc/srcgen/SrcGenPlugin.scala
@@ -129,10 +129,9 @@ object SrcGenPlugin extends AutoPlugin {
     muSrcGenIdlType := IdlType.Unknown,
     muSrcGenIdlExtension := {
       muSrcGenIdlType.value match {
-        case IdlType.Avro    => "avdl"
-        case IdlType.Proto   => "proto"
-        case IdlType.OpenAPI => "open api"
-        case _               => "unknown"
+        case IdlType.Avro  => "avdl"
+        case IdlType.Proto => "proto"
+        case _             => "unknown"
       }
     },
     muSrcGenSerializationType := SerializationType.Avro,

--- a/plugin/src/main/scala/higherkindness/mu/rpc/srcgen/SrcGenPlugin.scala
+++ b/plugin/src/main/scala/higherkindness/mu/rpc/srcgen/SrcGenPlugin.scala
@@ -70,7 +70,7 @@ object SrcGenPlugin extends AutoPlugin {
     lazy val muSrcGenTargetDir: SettingKey[File] =
       settingKey[File](
         "The Scala target directory, where the `srcGen` task will write the generated files " +
-          "in sub-packages based on the namespaces declared in the IDL files."
+          "in subpackages based on the namespaces declared in the IDL files."
       )
 
     lazy val muSrcGenBigDecimal: SettingKey[BigDecimalTypeGen] =

--- a/plugin/src/main/scala/higherkindness/mu/rpc/srcgen/SrcGenPlugin.scala
+++ b/plugin/src/main/scala/higherkindness/mu/rpc/srcgen/SrcGenPlugin.scala
@@ -129,8 +129,8 @@ object SrcGenPlugin extends AutoPlugin {
     muSrcGenIdlType := IdlType.Unknown,
     muSrcGenIdlExtension := {
       muSrcGenIdlType.value match {
-        case IdlType.Avro  => "avdl"
-        case IdlType.Proto => "proto"
+        case IdlType.Avro    => "avdl"
+        case IdlType.Proto   => "proto"
         case IdlType.OpenAPI => "open api"
         case _               => "unknown"
       }

--- a/plugin/src/main/scala/higherkindness/mu/rpc/srcgen/SrcGenPlugin.scala
+++ b/plugin/src/main/scala/higherkindness/mu/rpc/srcgen/SrcGenPlugin.scala
@@ -31,7 +31,7 @@ import scala.concurrent.ExecutionContext.global
 
 object SrcGenPlugin extends AutoPlugin {
 
-  override def trigger: PluginTrigger = allRequirements
+  override def trigger: PluginTrigger = noTrigger
 
   object autoImport {
 
@@ -70,7 +70,7 @@ object SrcGenPlugin extends AutoPlugin {
     lazy val muSrcGenTargetDir: SettingKey[File] =
       settingKey[File](
         "The Scala target directory, where the `srcGen` task will write the generated files " +
-          "in subpackages based on the namespaces declared in the IDL files."
+          "in sub-packages based on the namespaces declared in the IDL files."
       )
 
     lazy val muSrcGenBigDecimal: SettingKey[BigDecimalTypeGen] =
@@ -131,6 +131,8 @@ object SrcGenPlugin extends AutoPlugin {
       muSrcGenIdlType.value match {
         case IdlType.Avro  => "avdl"
         case IdlType.Proto => "proto"
+        // I thought we needed to include this; I wonder if we've never noticed bc we never use it?
+        case IdlType.OpenAPI => "open api" 
         case _             => "unknown"
       }
     },

--- a/plugin/src/main/scala/higherkindness/mu/rpc/srcgen/SrcGenPlugin.scala
+++ b/plugin/src/main/scala/higherkindness/mu/rpc/srcgen/SrcGenPlugin.scala
@@ -132,8 +132,8 @@ object SrcGenPlugin extends AutoPlugin {
         case IdlType.Avro  => "avdl"
         case IdlType.Proto => "proto"
         // I thought we needed to include this; I wonder if we've never noticed bc we never use it?
-        case IdlType.OpenAPI => "open api" 
-        case _             => "unknown"
+        case IdlType.OpenAPI => "open api"
+        case _               => "unknown"
       }
     },
     muSrcGenSerializationType := SerializationType.Avro,

--- a/plugin/src/main/scala/higherkindness/mu/rpc/srcgen/SrcGenPlugin.scala
+++ b/plugin/src/main/scala/higherkindness/mu/rpc/srcgen/SrcGenPlugin.scala
@@ -131,7 +131,6 @@ object SrcGenPlugin extends AutoPlugin {
       muSrcGenIdlType.value match {
         case IdlType.Avro  => "avdl"
         case IdlType.Proto => "proto"
-        // I thought we needed to include this; I wonder if we've never noticed bc we never use it?
         case IdlType.OpenAPI => "open api"
         case _               => "unknown"
       }

--- a/plugin/src/sbt-test/sbt-mu-srcgen/avroWithSchema/build.sbt
+++ b/plugin/src/sbt-test/sbt-mu-srcgen/avroWithSchema/build.sbt
@@ -1,7 +1,12 @@
 version := sys.props("version")
 
-libraryDependencies ++= Seq(
-  "io.higherkindness" %% "mu-rpc-service" % sys.props("mu")
-)
-
 addCompilerPlugin("org.scalamacros" % "paradise" % "2.1.1" cross CrossVersion.patch)
+
+lazy val root = project
+  .in(file("."))
+  .enablePlugins(SrcGenPlugin)
+  .settings(Seq(
+    libraryDependencies ++= Seq(
+  "io.higherkindness" %% "mu-rpc-service" % sys.props("mu"),
+  )
+  ))

--- a/plugin/src/sbt-test/sbt-mu-srcgen/avroWithSchema/build.sbt
+++ b/plugin/src/sbt-test/sbt-mu-srcgen/avroWithSchema/build.sbt
@@ -5,3 +5,5 @@ enablePlugins(SrcGenPlugin)
 libraryDependencies ++= Seq(
   "io.higherkindness" %% "mu-rpc-service" % sys.props("mu")
 )
+
+addCompilerPlugin("org.scalamacros" % "paradise" % "2.1.1" cross CrossVersion.patch)

--- a/plugin/src/sbt-test/sbt-mu-srcgen/avroWithSchema/build.sbt
+++ b/plugin/src/sbt-test/sbt-mu-srcgen/avroWithSchema/build.sbt
@@ -1,12 +1,7 @@
 version := sys.props("version")
 
-addCompilerPlugin("org.scalamacros" % "paradise" % "2.1.1" cross CrossVersion.patch)
+enablePlugins(SrcGenPlugin)
 
-lazy val root = project
-  .in(file("."))
-  .enablePlugins(SrcGenPlugin)
-  .settings(Seq(
-    libraryDependencies ++= Seq(
-  "io.higherkindness" %% "mu-rpc-service" % sys.props("mu"),
-  )
-  ))
+libraryDependencies ++= Seq(
+  "io.higherkindness" %% "mu-rpc-service" % sys.props("mu")
+)

--- a/plugin/src/sbt-test/sbt-mu-srcgen/basic/build.sbt
+++ b/plugin/src/sbt-test/sbt-mu-srcgen/basic/build.sbt
@@ -1,5 +1,10 @@
 version := sys.props("version")
 
-libraryDependencies ++= Seq(
-  "io.higherkindness" %% "mu-rpc-server" % sys.props("mu")
-)
+lazy val root = project
+  .in(file("."))
+  .enablePlugins(SrcGenPlugin)
+  .settings(Seq(
+    libraryDependencies ++= Seq(
+  "io.higherkindness" %% "mu-rpc-server" % sys.props("mu"),
+  )
+  ))

--- a/plugin/src/sbt-test/sbt-mu-srcgen/basic/build.sbt
+++ b/plugin/src/sbt-test/sbt-mu-srcgen/basic/build.sbt
@@ -1,10 +1,7 @@
 version := sys.props("version")
 
-lazy val root = project
-  .in(file("."))
-  .enablePlugins(SrcGenPlugin)
-  .settings(Seq(
-    libraryDependencies ++= Seq(
-  "io.higherkindness" %% "mu-rpc-server" % sys.props("mu"),
-  )
-  ))
+enablePlugins(SrcGenPlugin)
+
+libraryDependencies ++= Seq(
+  "io.higherkindness" %% "mu-rpc-server" % sys.props("mu")
+)

--- a/plugin/src/sbt-test/sbt-mu-srcgen/compendium/build.sbt
+++ b/plugin/src/sbt-test/sbt-mu-srcgen/compendium/build.sbt
@@ -1,5 +1,10 @@
 version := sys.props("version")
 
-libraryDependencies ++= Seq(
-  "io.higherkindness" %% "mu-rpc-server" % sys.props("mu")
-)
+lazy val root = project
+  .in(file("."))
+  .enablePlugins(SrcGenPlugin)
+  .settings(Seq(
+    libraryDependencies ++= Seq(
+  "io.higherkindness" %% "mu-rpc-server" % sys.props("mu"),
+  )
+  ))

--- a/plugin/src/sbt-test/sbt-mu-srcgen/compendium/build.sbt
+++ b/plugin/src/sbt-test/sbt-mu-srcgen/compendium/build.sbt
@@ -1,10 +1,7 @@
 version := sys.props("version")
 
-lazy val root = project
-  .in(file("."))
-  .enablePlugins(SrcGenPlugin)
-  .settings(Seq(
-    libraryDependencies ++= Seq(
-  "io.higherkindness" %% "mu-rpc-server" % sys.props("mu"),
-  )
-  ))
+enablePlugins(SrcGenPlugin)
+
+libraryDependencies ++= Seq(
+  "io.higherkindness" %% "mu-rpc-server" % sys.props("mu")
+)

--- a/plugin/src/sbt-test/sbt-mu-srcgen/gzipCompression/build.sbt
+++ b/plugin/src/sbt-test/sbt-mu-srcgen/gzipCompression/build.sbt
@@ -1,7 +1,12 @@
 version := sys.props("version")
 
-libraryDependencies ++= Seq(
-  "io.higherkindness" %% "mu-rpc-service" % sys.props("mu")
-)
+lazy val root = project
+  .in(file("."))
+  .enablePlugins(SrcGenPlugin)
+  .settings(Seq(
+    libraryDependencies ++= Seq(
+  "io.higherkindness" %% "mu-rpc-service" % sys.props("mu"),
+  )
+  ))
 
 addCompilerPlugin("org.scalamacros" % "paradise" % "2.1.1" cross CrossVersion.patch)

--- a/plugin/src/sbt-test/sbt-mu-srcgen/gzipCompression/build.sbt
+++ b/plugin/src/sbt-test/sbt-mu-srcgen/gzipCompression/build.sbt
@@ -1,12 +1,9 @@
 version := sys.props("version")
 
-lazy val root = project
-  .in(file("."))
-  .enablePlugins(SrcGenPlugin)
-  .settings(Seq(
-    libraryDependencies ++= Seq(
-  "io.higherkindness" %% "mu-rpc-service" % sys.props("mu"),
-  )
-  ))
+enablePlugins(SrcGenPlugin)
+
+libraryDependencies ++= Seq(
+  "io.higherkindness" %% "mu-rpc-service" % sys.props("mu")
+)
 
 addCompilerPlugin("org.scalamacros" % "paradise" % "2.1.1" cross CrossVersion.patch)

--- a/plugin/src/sbt-test/sbt-mu-srcgen/idiomaticEndpoints/build.sbt
+++ b/plugin/src/sbt-test/sbt-mu-srcgen/idiomaticEndpoints/build.sbt
@@ -1,11 +1,9 @@
 version := sys.props("version")
-lazy val root = project
-  .in(file("."))
-  .enablePlugins(SrcGenPlugin)
-  .settings(Seq(
-    libraryDependencies ++= Seq(
-  "io.higherkindness" %% "mu-rpc-service" % sys.props("mu"),
-  )
-  ))
+
+enablePlugins(SrcGenPlugin)
+
+libraryDependencies ++= Seq(
+  "io.higherkindness" %% "mu-rpc-service" % sys.props("mu")
+)
 
 addCompilerPlugin("org.scalamacros" % "paradise" % "2.1.1" cross CrossVersion.patch)

--- a/plugin/src/sbt-test/sbt-mu-srcgen/idiomaticEndpoints/build.sbt
+++ b/plugin/src/sbt-test/sbt-mu-srcgen/idiomaticEndpoints/build.sbt
@@ -1,7 +1,11 @@
 version := sys.props("version")
-
-libraryDependencies ++= Seq(
-  "io.higherkindness" %% "mu-rpc-service" % sys.props("mu")
-)
+lazy val root = project
+  .in(file("."))
+  .enablePlugins(SrcGenPlugin)
+  .settings(Seq(
+    libraryDependencies ++= Seq(
+  "io.higherkindness" %% "mu-rpc-service" % sys.props("mu"),
+  )
+  ))
 
 addCompilerPlugin("org.scalamacros" % "paradise" % "2.1.1" cross CrossVersion.patch)

--- a/plugin/src/sbt-test/sbt-mu-srcgen/importMarshallers/build.sbt
+++ b/plugin/src/sbt-test/sbt-mu-srcgen/importMarshallers/build.sbt
@@ -1,9 +1,14 @@
 version := sys.props("version")
 
-libraryDependencies ++= Seq(
+lazy val root = project
+  .in(file("."))
+  .enablePlugins(SrcGenPlugin)
+  .settings(Seq(
+    libraryDependencies ++= Seq(
   "io.higherkindness" %% "mu-rpc-service" % sys.props("mu"),
   "io.higherkindness" %% "mu-rpc-marshallers-jodatime" % sys.props("mu")
-)
+  )
+  ))
 
 addCompilerPlugin("org.scalamacros" % "paradise" % "2.1.1" cross CrossVersion.patch)
 
@@ -13,3 +18,10 @@ checkCustomImport := {
   val lines = sbt.io.IO.readLines(generatedFile)
   assert(lines.contains("import com.sample.marshallers._"))
 }
+
+
+lazy val util = (project in file("plugin/src/sbt-test"))
+  .enablePlugins(SrcGenPlugin)
+  .settings(
+    name := "hello-util"
+  )

--- a/plugin/src/sbt-test/sbt-mu-srcgen/importMarshallers/build.sbt
+++ b/plugin/src/sbt-test/sbt-mu-srcgen/importMarshallers/build.sbt
@@ -1,14 +1,11 @@
 version := sys.props("version")
 
-lazy val root = project
-  .in(file("."))
-  .enablePlugins(SrcGenPlugin)
-  .settings(Seq(
-    libraryDependencies ++= Seq(
+enablePlugins(SrcGenPlugin)
+
+libraryDependencies ++= Seq(
   "io.higherkindness" %% "mu-rpc-service" % sys.props("mu"),
   "io.higherkindness" %% "mu-rpc-marshallers-jodatime" % sys.props("mu")
-  )
-  ))
+)
 
 addCompilerPlugin("org.scalamacros" % "paradise" % "2.1.1" cross CrossVersion.patch)
 
@@ -18,10 +15,3 @@ checkCustomImport := {
   val lines = sbt.io.IO.readLines(generatedFile)
   assert(lines.contains("import com.sample.marshallers._"))
 }
-
-
-lazy val util = (project in file("plugin/src/sbt-test"))
-  .enablePlugins(SrcGenPlugin)
-  .settings(
-    name := "hello-util"
-  )

--- a/plugin/src/sbt-test/sbt-mu-srcgen/srcGenFromDirs/build.sbt
+++ b/plugin/src/sbt-test/sbt-mu-srcgen/srcGenFromDirs/build.sbt
@@ -2,6 +2,7 @@ import higherkindness.mu.rpc.srcgen.Model.IdlType
 
 lazy val root = project
   .in(file("."))
+  .enablePlugins(SrcGenPlugin)
   .settings(name := "root")
   .settings(version := "1.0.0")
   .settings(Seq(

--- a/plugin/src/sbt-test/sbt-mu-srcgen/srcGenFromJars/build.sbt
+++ b/plugin/src/sbt-test/sbt-mu-srcgen/srcGenFromJars/build.sbt
@@ -22,7 +22,6 @@ lazy val domain = project
 
 lazy val root = project
   .in(file("."))
-  .enablePlugins(SrcGenPlugin)
   .settings(name := "root")
   .settings(Seq(
     version := sys.props("version"),

--- a/plugin/src/sbt-test/sbt-mu-srcgen/srcGenFromJars/build.sbt
+++ b/plugin/src/sbt-test/sbt-mu-srcgen/srcGenFromJars/build.sbt
@@ -21,6 +21,7 @@ lazy val domain = project
 
 lazy val root = project
   .in(file("."))
+  .enablePlugins(SrcGenPlugin)
   .settings(name := "root")
   .settings(Seq(
     version := sys.props("version"),

--- a/plugin/src/sbt-test/sbt-mu-srcgen/srcGenFromJars/build.sbt
+++ b/plugin/src/sbt-test/sbt-mu-srcgen/srcGenFromJars/build.sbt
@@ -22,6 +22,7 @@ lazy val domain = project
 
 lazy val root = project
   .in(file("."))
+  .enablePlugins(SrcGenPlugin)
   .settings(name := "root")
   .settings(Seq(
     version := sys.props("version"),

--- a/plugin/src/sbt-test/sbt-mu-srcgen/srcGenFromJars/build.sbt
+++ b/plugin/src/sbt-test/sbt-mu-srcgen/srcGenFromJars/build.sbt
@@ -3,6 +3,7 @@ import higherkindness.mu.rpc.srcgen.Model.IdlType
 lazy val domain = project
   .in(file("domain"))
   .settings(name := "domain")
+  .enablePlugins(SrcGenPlugin)
   .settings(
     Seq(
       organization := "foo.bar",

--- a/plugin/src/sbt-test/sbt-mu-srcgen/srcOpenApiGenFromDirs/build.sbt
+++ b/plugin/src/sbt-test/sbt-mu-srcgen/srcOpenApiGenFromDirs/build.sbt
@@ -14,6 +14,7 @@ lazy val root = project
   .in(file("."))
   .settings(name := "root")
   .settings(version := "1.0.0")
+  .enablePlugins(SrcGenPlugin)
   .settings(Seq(
     muSrcGenIdlType := IdlType.OpenAPI,
     muSrcGenSourceDirs := Seq((Compile / resourceDirectory).value),

--- a/plugin/src/sbt-test/sbt-mu-srcgen/srcProtoGenFromDirs/build.sbt
+++ b/plugin/src/sbt-test/sbt-mu-srcgen/srcProtoGenFromDirs/build.sbt
@@ -2,6 +2,7 @@ import higherkindness.mu.rpc.srcgen.Model.IdlType
 
 lazy val root = project
   .in(file("."))
+    .enablePlugins(SrcGenPlugin)
   .settings(
     muSrcGenIdlType := IdlType.Proto,
     muSrcGenTargetDir := (Compile / sourceManaged).value / "compiled_proto",

--- a/plugin/src/sbt-test/sbt-mu-srcgen/srcProtoGenFromDirs/build.sbt
+++ b/plugin/src/sbt-test/sbt-mu-srcgen/srcProtoGenFromDirs/build.sbt
@@ -2,7 +2,7 @@ import higherkindness.mu.rpc.srcgen.Model.IdlType
 
 lazy val root = project
   .in(file("."))
-    .enablePlugins(SrcGenPlugin)
+  .enablePlugins(SrcGenPlugin)
   .settings(
     muSrcGenIdlType := IdlType.Proto,
     muSrcGenTargetDir := (Compile / sourceManaged).value / "compiled_proto",

--- a/plugin/src/sbt-test/sbt-mu-srcgen/srcProtoGenMonix/build.sbt
+++ b/plugin/src/sbt-test/sbt-mu-srcgen/srcProtoGenMonix/build.sbt
@@ -3,6 +3,7 @@ import higherkindness.mu.rpc.srcgen.Model.IdlType
 
 lazy val root = project
   .in(file("."))
+  .enablePlugins(SrcGenPlugin)
   .settings(
     muSrcGenIdlType := IdlType.Proto,
     muSrcGenTargetDir := (Compile / sourceManaged).value / "generated_from_proto",


### PR DESCRIPTION
Partially closes https://github.com/higherkindness/sbt-mu-srcgen/issues/38; there's another PR (currently WIP) for the `mu-scala` microsite changes that explain the changes around using and enabling this plugin.

The change is pretty simple and I updated the readme to explain how users of this plugin will have to enable it different depending on what version they want to use.  However, this led me to think of a question that I want to pose here to get folks' opinions: _how can we make it so that people who upgrade to the latest version of this plugin immediately notice the new behavior w.r.t needing to manually enable it?_ Even though the README makes it clear, I imagine a scenario where a downstream user who is automatically using the latest versions of all of their dependencies (such as someone using scala-steward) may unintentionally upgrade this version and it will compile but silently change the underlying behavior of their `build.sbt`.  Does anyone know of a way to obviously warn about breaking changes during a build/compile step between two versions of a plugin?

EDIT: So the failing tests actually gave me a bit of a hint; it looks like modules may fail to compile if they try and use anything related to the `SrcGenPlugin` but they haven't enabled it.  That's giving me hope that at least when the version bump happens folks will have compiler errors rather than silent errors.  I am curious, though, if there's a way to put a link to the documentation or even just a message to use `.enablePlugins(SrcGenPlugin)` as part of the compiler error for downstream projects -- I think it'll help with preventing confusion among any users of this plugin.