### PR TITLE
Write the error output from Protobuf parse exceptions

### DIFF
--- a/core/src/main/scala/higherkindness/mu/rpc/srcgen/avro/AvroSrcGenerator.scala
+++ b/core/src/main/scala/higherkindness/mu/rpc/srcgen/avro/AvroSrcGenerator.scala
@@ -112,6 +112,7 @@ final case class AvroSrcGenerator(
       s"${protocol.getNamespace.replace('.', '/')}/${protocol.getName}$ScalaFileExtension"
 
     val schemaGenerator = if (protocol.getMessages.isEmpty) adtGenerator else mainGenerator
+
     val schemaLines = schemaGenerator
       .protocolToStrings(protocol)
       .mkString

--- a/core/src/main/scala/higherkindness/mu/rpc/srcgen/avro/AvroSrcGenerator.scala
+++ b/core/src/main/scala/higherkindness/mu/rpc/srcgen/avro/AvroSrcGenerator.scala
@@ -164,7 +164,7 @@ final case class AvroSrcGenerator(
     outputPath -> outputCode
   }
 
-  def validateRequest(request: Schema): ErrorsOr[String] = {
+  private def validateRequest(request: Schema): ErrorsOr[String] = {
     val requestArgs = request.getFields.asScala
     requestArgs.toList match {
       case Nil =>
@@ -178,7 +178,7 @@ final case class AvroSrcGenerator(
     }
   }
 
-  def validateResponse(response: Schema): ErrorsOr[String] = {
+  private def validateResponse(response: Schema): ErrorsOr[String] = {
     response.getType match {
       case Schema.Type.NULL =>
         EmptyType.validNel

--- a/core/src/main/scala/higherkindness/mu/rpc/srcgen/proto/ProtoSrcGenerator.scala
+++ b/core/src/main/scala/higherkindness/mu/rpc/srcgen/proto/ProtoSrcGenerator.scala
@@ -42,7 +42,9 @@ import higherkindness.skeuomorph.protobuf.{ProtobufF, Protocol}
 
 object ProtoSrcGenerator {
 
-  final case class ProtobufSrcGenException(message: String) extends NoStackTrace
+  final case class ProtobufSrcGenException(message: String) extends NoStackTrace {
+    override def toString: String = s"ProtoBufSrcGenException: $message"
+  }
 
   def build(
       compressionTypeGen: CompressionTypeGen,

--- a/core/src/test/resources/avro/Invalid.avdl
+++ b/core/src/test/resources/avro/Invalid.avdl
@@ -1,0 +1,19 @@
+@namespace("foo.bar")
+protocol MyGreeterService {
+
+  record HelloRequest {
+    string arg1;
+    union { null, string } arg2;
+    array<string> arg3;
+  }
+
+  record HelloResponse {
+    string arg1;
+    union { null, string } arg2;
+    array<string>  arg3;
+  }
+
+  string sayHelloAvro(foo.bar.HelloRequest arg);
+
+  void sayNothingAvro();
+}

--- a/core/src/test/resources/proto/broken.proto
+++ b/core/src/test/resources/proto/broken.proto
@@ -1,0 +1,6 @@
+syntax = "proto3";
+
+message Broken {
+    string name = 1;
+    string nick = 2;
+}

--- a/core/src/test/scala/higherkindness/mu/rpc/srcgen/AvroSrcGenTests.scala
+++ b/core/src/test/scala/higherkindness/mu/rpc/srcgen/AvroSrcGenTests.scala
@@ -16,6 +16,7 @@
 
 package higherkindness.mu.rpc.srcgen
 
+import cats.data.Validated
 import cats.data.Validated.Valid
 
 import scala.io._
@@ -57,7 +58,14 @@ class AvroSrcGenTests extends AnyWordSpec with Matchers with OneInstancePerTest 
         )
       }
 
-      response shouldBe Some(("foo/bar/MyGreeterService.scala", Validated.invalidNel("RPC method response parameter has non-record response type 'STRING'")))
+      response shouldBe Some(
+        (
+          "foo/bar/MyGreeterService.scala",
+          Validated.invalidNel(
+            "RPC method response parameter has non-record response type 'STRING'"
+          )
+        )
+      )
     }
   }
 

--- a/core/src/test/scala/higherkindness/mu/rpc/srcgen/AvroSrcGenTests.scala
+++ b/core/src/test/scala/higherkindness/mu/rpc/srcgen/AvroSrcGenTests.scala
@@ -57,10 +57,7 @@ class AvroSrcGenTests extends AnyWordSpec with Matchers with OneInstancePerTest 
         )
       }
 
-      val expectedResponse =
-        "Some((foo/bar/MyGreeterService.scala,Invalid(NonEmptyList(RPC method response parameter has non-record response type 'STRING'))))"
-
-      assert(response.toString == expectedResponse)
+      response shouldBe Some(("foo/bar/MyGreeterService.scala", Validated.invalidNel("RPC method response parameter has non-record response type 'STRING'")))
     }
   }
 

--- a/core/src/test/scala/higherkindness/mu/rpc/srcgen/ProtoSrcGenTests.scala
+++ b/core/src/test/scala/higherkindness/mu/rpc/srcgen/ProtoSrcGenTests.scala
@@ -26,6 +26,7 @@ import higherkindness.mu.rpc.srcgen.Model.{
   UseIdiomaticEndpoints
 }
 import higherkindness.mu.rpc.srcgen.proto.ProtoSrcGenerator
+import higherkindness.mu.rpc.srcgen.proto.ProtoSrcGenerator.ProtobufSrcGenException
 import org.scalatest._
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
@@ -73,6 +74,25 @@ class ProtoSrcGenTests extends AnyWordSpec with Matchers with OneInstancePerTest
         bookExpectation(tpe => s"_root_.monix.reactive.Observable[$tpe]").clean
 
       result shouldBe Some(("com/proto/book.scala", expectedFileContent))
+    }
+
+    "throw an exception on an incorrect Protobuf schema" in {
+      val caught = intercept[ProtobufSrcGenException] {
+        ProtoSrcGenerator
+          .build(
+            NoCompressionGen,
+            UseIdiomaticEndpoints(false),
+            MonixObservable,
+            new java.io.File(".")
+          )
+          .generateFrom(
+            files = Set(protoFile("broken")),
+            serializationType = SerializationType.Protobuf
+          )
+      }
+
+      assert(caught.toString.contains("ProtoBufSrcGenException"))
+
     }
 
   }

--- a/core/src/test/scala/higherkindness/mu/rpc/srcgen/ProtoSrcGenTests.scala
+++ b/core/src/test/scala/higherkindness/mu/rpc/srcgen/ProtoSrcGenTests.scala
@@ -77,7 +77,7 @@ class ProtoSrcGenTests extends AnyWordSpec with Matchers with OneInstancePerTest
     }
 
     "throw an exception on an incorrect Protobuf schema" in {
-      val caught = intercept[ProtobufSrcGenException] {
+      assertThrows[ProtobufSrcGenException] {
         ProtoSrcGenerator
           .build(
             NoCompressionGen,
@@ -90,9 +90,6 @@ class ProtoSrcGenTests extends AnyWordSpec with Matchers with OneInstancePerTest
             serializationType = SerializationType.Protobuf
           )
       }
-
-      assert(caught.toString.contains("ProtoBufSrcGenException"))
-
     }
 
   }


### PR DESCRIPTION
Closes #82.  Turns out we just needed to override the `toString` method when using our custom exception.

Old output:
```
$ muSrcGen
[error] stack trace is suppressed; run last protocol / muSrcGen for the full output
[error] (protocol / muSrcGen) higherkindness.mu.rpc.srcgen.proto.ProtoSrcGenerator$ProtobufSrcGenException
[error] Total time: 1 s, completed Aug 13, 2020, 10:49:20 AM
```

New output:
```
$ muSrcGen
[error] stack trace is suppressed; run last protocol / muSrcGen for the full output
[error] (protocol / muSrcGen) Failed to generate Scala source from Protobuf file /Users/dylan/Work/playground/test-protobuf-packages/protocol/target/scala-2.13/resource_managed/main/proto/proto/hello.proto. Error details: Failed to parse package name: <input>:1: error: illegal start of simple expression
[error]
[error] ^
[error] Total time: 1 s, completed Aug 13, 2020, 11:25:16 AM
```