### PR TITLE
Only upgrade patch fixes in Scala

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,0 +1,3 @@
+updates.pin = [
+  { groupId = "org.scala-lang", artifactId="scala-library", version="2.12." }
+]


### PR DESCRIPTION
This is an SBT plugin, so only Scala 2.12.x is supported at this moment. Let's save some CI runs.