### PR TITLE
Removes references to Monix

### DIFF
--- a/core/src/main/scala/higherkindness/mu/rpc/srcgen/Model.scala
+++ b/core/src/main/scala/higherkindness/mu/rpc/srcgen/Model.scala
@@ -69,10 +69,6 @@ object Model {
   case object GzipGen                      extends CompressionTypeGen
   case object NoCompressionGen             extends CompressionTypeGen
 
-  sealed trait StreamingImplementation
-  case object Fs2Stream       extends StreamingImplementation
-  case object MonixObservable extends StreamingImplementation
-
   sealed abstract class AvroGeneratorTypeGen extends Product with Serializable
   case object AvrohuggerGen                  extends AvroGeneratorTypeGen
   case object SkeumorphGen                   extends AvroGeneratorTypeGen

--- a/core/src/main/scala/higherkindness/mu/rpc/srcgen/SrcGenApplication.scala
+++ b/core/src/main/scala/higherkindness/mu/rpc/srcgen/SrcGenApplication.scala
@@ -33,7 +33,6 @@ object SrcGenApplication {
       bigDecimalTypeGen: BigDecimalTypeGen,
       compressionTypeGen: CompressionTypeGen,
       useIdiomaticEndpoints: Boolean,
-      streamingImplementation: StreamingImplementation,
       idlTargetDir: File,
       resourcesBasePath: Path,
       httpImpl: HttpImpl,
@@ -45,7 +44,6 @@ object SrcGenApplication {
     }
     new GeneratorApplication(
       ProtoSrcGenerator(
-        streamingImplementation,
         idlTargetDir,
         compressionType,
         useIdiomaticEndpoints,
@@ -60,7 +58,7 @@ object SrcGenApplication {
             useIdiomaticEndpoints
           )
         case Model.SkeumorphGen =>
-          AvroSrcGenerator(compressionType, streamingImplementation, useIdiomaticEndpoints)
+          AvroSrcGenerator(compressionType, useIdiomaticEndpoints)
       },
       OpenApiSrcGenerator(
         httpImpl,

--- a/core/src/test/scala/higherkindness/mu/rpc/srcgen/AvroScalaGeneratorArbitrary.scala
+++ b/core/src/test/scala/higherkindness/mu/rpc/srcgen/AvroScalaGeneratorArbitrary.scala
@@ -30,7 +30,6 @@ trait AvroScalaGeneratorArbitrary {
       serializationType: SerializationType,
       marshallersImports: List[MarshallersImport],
       compressionType: CompressionType,
-      streamingImplementation: StreamingImplementation,
       useIdiomaticEndpoints: Boolean = true
   )
 
@@ -68,12 +67,11 @@ trait AvroScalaGeneratorArbitrary {
 
   def scenarioArbitrary(generateOutput: GenerateOutput): Arbitrary[Scenario] = Arbitrary {
     for {
-      inputResourcePath       <- Gen.oneOf("/avro/GreeterService.avpr", "/avro/GreeterService.avdl")
-      serializationType       <- Gen.const(Avro)
-      marshallersImports      <- Gen.listOf(marshallersImportGen(serializationType))
-      compressionType         <- Gen.oneOf(CompressionType.Gzip, CompressionType.Identity)
-      streamingImplementation <- Gen.oneOf(MonixObservable, Fs2Stream)
-      useIdiomaticEndpoints   <- Arbitrary.arbBool.arbitrary
+      inputResourcePath     <- Gen.oneOf("/avro/GreeterService.avpr", "/avro/GreeterService.avdl")
+      serializationType     <- Gen.const(Avro)
+      marshallersImports    <- Gen.listOf(marshallersImportGen(serializationType))
+      compressionType       <- Gen.oneOf(CompressionType.Gzip, CompressionType.Identity)
+      useIdiomaticEndpoints <- Arbitrary.arbBool.arbitrary
     } yield Scenario(
       Set(inputResourcePath),
       generateOutput(
@@ -87,7 +85,6 @@ trait AvroScalaGeneratorArbitrary {
       serializationType,
       marshallersImports,
       compressionType,
-      streamingImplementation,
       useIdiomaticEndpoints
     )
   }

--- a/core/src/test/scala/higherkindness/mu/rpc/srcgen/AvroSrcGenTests.scala
+++ b/core/src/test/scala/higherkindness/mu/rpc/srcgen/AvroSrcGenTests.scala
@@ -100,7 +100,7 @@ class AvroSrcGenTests extends AnyWordSpec with Matchers with OneInstancePerTest 
 
     "return a non-empty list of errors instead of generating code from an invalid IDL file" in {
       val actual :: Nil = {
-        AvroSrcGenerator(CompressionType.Identity, MonixObservable, true).generateFrom(
+        AvroSrcGenerator(CompressionType.Identity, true).generateFrom(
           Set(new File(getClass.getResource("/avro/Invalid.avdl").toURI)),
           Avro
         )
@@ -120,7 +120,6 @@ class AvroSrcGenTests extends AnyWordSpec with Matchers with OneInstancePerTest 
     val output =
       AvroSrcGenerator(
         scenario.compressionType,
-        scenario.streamingImplementation,
         scenario.useIdiomaticEndpoints
       ).generateFrom(
         scenario.inputResourcesPath.map(path => new File(getClass.getResource(path).toURI)),

--- a/core/src/test/scala/higherkindness/mu/rpc/srcgen/ProtoSrcGenTests.scala
+++ b/core/src/test/scala/higherkindness/mu/rpc/srcgen/ProtoSrcGenTests.scala
@@ -33,9 +33,9 @@ class ProtoSrcGenTests extends AnyWordSpec with Matchers with OneInstancePerTest
 
   "Proto Scala Generator" should {
 
-    "generate the expected Scala code (FS2 stream)" in {
+    "generate the expected Scala code" in {
       val result: Option[(String, String)] =
-        ProtoSrcGenerator(Fs2Stream, protocVersion = protocVersion)
+        ProtoSrcGenerator(protocVersion = protocVersion)
           .generateFrom(
             files = Set(protoFile("book")),
             serializationType = SerializationType.Protobuf
@@ -49,27 +49,9 @@ class ProtoSrcGenTests extends AnyWordSpec with Matchers with OneInstancePerTest
       result shouldBe Some(("com/proto/book.scala", expectedFileContent.clean))
     }
 
-    "generate the expected Scala code (Monix Observable)" in {
-      val result: Option[(String, String)] =
-        ProtoSrcGenerator(MonixObservable, protocVersion = protocVersion)
-          .generateFrom(
-            files = Set(protoFile("book")),
-            serializationType = SerializationType.Protobuf
-          )
-          .flatMap { r =>
-            r.output.toOption.map(o => (o.path.toString, o.contents.mkString("\n").clean))
-          }
-          .headOption
-
-      val expectedFileContent =
-        bookExpectation(tpe => s"_root_.monix.reactive.Observable[$tpe]").clean
-
-      result shouldBe Some(("com/proto/book.scala", expectedFileContent))
-    }
-
     "throw an exception on an invalid Protobuf schema" in {
       assertThrows[ProtobufCompilationException] {
-        ProtoSrcGenerator(MonixObservable, protocVersion = protocVersion)
+        ProtoSrcGenerator(protocVersion = protocVersion)
           .generateFrom(
             files = Set(protoFile("broken")),
             serializationType = SerializationType.Protobuf

--- a/plugin/src/main/scala/higherkindness/mu/rpc/srcgen/SrcGenPlugin.scala
+++ b/plugin/src/main/scala/higherkindness/mu/rpc/srcgen/SrcGenPlugin.scala
@@ -99,13 +99,6 @@ object SrcGenPlugin extends AutoPlugin {
           "`Http4sV20` by default."
       )
 
-    lazy val muSrcGenStreamingImplementation: SettingKey[StreamingImplementation] =
-      settingKey[StreamingImplementation](
-        "The streaming implementation to use when generating Scala sources from IDL definitions that involve streaming. " +
-          "FS2 Stream and Monix Observable are the current supported implementations. " +
-          "By default, the streaming implementation is FS2 Stream."
-      )
-
     lazy val muSrcGenAvroGeneratorType: SettingKey[AvroGeneratorTypeGen] =
       settingKey[AvroGeneratorTypeGen](
         "Specifies the Avro generation type: `SkeumorphGen` or `AvrohuggerGen`. `SkeumorphGen` by default."
@@ -149,12 +142,11 @@ object SrcGenPlugin extends AutoPlugin {
           Nil
       }
     },
-    muSrcGenCompressionType         := NoCompressionGen,
-    muSrcGenIdiomaticEndpoints      := true,
-    muSrcGenOpenApiHttpImpl         := HttpImpl.Http4sV20,
-    muSrcGenStreamingImplementation := Fs2Stream,
-    muSrcGenAvroGeneratorType       := SkeumorphGen,
-    muSrcGenProtocVersion           := protocDefaultVersion
+    muSrcGenCompressionType    := NoCompressionGen,
+    muSrcGenIdiomaticEndpoints := true,
+    muSrcGenOpenApiHttpImpl    := HttpImpl.Http4sV20,
+    muSrcGenAvroGeneratorType  := SkeumorphGen,
+    muSrcGenProtocVersion      := protocDefaultVersion
   )
 
   lazy val taskSettings: Seq[Def.Setting[_]] = {
@@ -193,7 +185,6 @@ object SrcGenPlugin extends AutoPlugin {
                 muSrcGenBigDecimal.value,
                 muSrcGenCompressionType.value,
                 muSrcGenIdiomaticEndpoints.value,
-                muSrcGenStreamingImplementation.value,
                 muSrcGenIdlTargetDir.value,
                 (Compile / resourceManaged).value.toPath,
                 muSrcGenOpenApiHttpImpl.value,


### PR DESCRIPTION
Relates to https://github.com/higherkindness/mu-scala/pull/1407

Removes the references to Monix (support was dropped as part of mu upgrade to cats-effect 3)