### PR TITLE
Scalapb validate

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -13,18 +13,19 @@ lazy val core = project
   .settings(moduleName := "mu-srcgen-core")
   .settings(
     libraryDependencies ++= Seq(
-      "org.typelevel"        %% "cats-core"           % "2.8.0",
-      "com.julianpeeters"    %% "avrohugger-core"     % "1.0.0",
-      "com.thesamet.scalapb" %% "compilerplugin"      % "0.11.11",
-      "org.scalameta"        %% "scalameta"           % "4.5.9",
-      "ch.epfl.scala"        %% "scalafix-core"       % "0.10.1",
-      "ch.epfl.scala"        %% "scalafix-cli"        % "0.10.1" cross CrossVersion.full,
-      "ch.epfl.scala"         % "scalafix-interfaces" % "0.10.1",
-      "org.scalatest"        %% "scalatest"           % "3.2.12"  % Test,
-      "org.scalacheck"       %% "scalacheck"          % "1.16.0"  % Test,
-      "org.scalatestplus"    %% "scalacheck-1-14"     % "3.2.2.0" % Test,
-      "org.slf4j"             % "slf4j-nop"           % "1.7.36"  % Test,
-      "org.scalameta"        %% "contrib"             % "4.1.6"   % Test
+      "org.typelevel"        %% "cats-core"                % "2.8.0",
+      "com.julianpeeters"    %% "avrohugger-core"          % "1.0.0",
+      "com.thesamet.scalapb" %% "compilerplugin"           % "0.11.11",
+      "com.thesamet.scalapb" %% "scalapb-validate-codegen" % "0.3.2",
+      "org.scalameta"        %% "scalameta"                % "4.5.9",
+      "ch.epfl.scala"        %% "scalafix-core"            % "0.10.1",
+      "ch.epfl.scala"        %% "scalafix-cli"             % "0.10.1" cross CrossVersion.full,
+      "ch.epfl.scala"         % "scalafix-interfaces"      % "0.10.1",
+      "org.scalatest"        %% "scalatest"                % "3.2.12"  % Test,
+      "org.scalacheck"       %% "scalacheck"               % "1.16.0"  % Test,
+      "org.scalatestplus"    %% "scalacheck-1-14"          % "3.2.2.0" % Test,
+      "org.slf4j"             % "slf4j-nop"                % "1.7.36"  % Test,
+      "org.scalameta"        %% "contrib"                  % "4.1.6"   % Test
     ),
     buildInfoPackage := "higherkindness.mu.rpc.srcgen",
     buildInfoKeys := Seq[BuildInfoKey](

--- a/plugin/src/sbt-test/sbt-mu-srcgen/srcProtoGenValidate/build.sbt
+++ b/plugin/src/sbt-test/sbt-mu-srcgen/srcProtoGenValidate/build.sbt
@@ -1,0 +1,18 @@
+import higherkindness.mu.rpc.srcgen.Model.IdlType
+
+ThisBuild / resolvers += Resolver.sonatypeRepo("snapshots")
+
+lazy val root = project
+  .in(file("."))
+  .enablePlugins(SrcGenPlugin)
+  .settings(
+    crossScalaVersions    := Seq("2.13.8", "3.1.1"),
+    muSrcGenIdlType       := IdlType.Proto,
+    muSrcGenTargetDir     := (Compile / sourceManaged).value / "compiled_proto",
+    muSrcGenValidateProto := true,
+    libraryDependencies ++= Seq(
+      "io.higherkindness" %% "mu-rpc-service" % sys.props("mu"),
+      "io.higherkindness" %% "mu-rpc-fs2"     % sys.props("mu"),
+      "com.thesamet.scalapb" %% "scalapb-validate-core" % scalapb.validate.compiler.BuildInfo.version % "protobuf"
+    )
+  )

--- a/plugin/src/sbt-test/sbt-mu-srcgen/srcProtoGenValidate/project/build.properties
+++ b/plugin/src/sbt-test/sbt-mu-srcgen/srcProtoGenValidate/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.7.1

--- a/plugin/src/sbt-test/sbt-mu-srcgen/srcProtoGenValidate/project/plugins.sbt
+++ b/plugin/src/sbt-test/sbt-mu-srcgen/srcProtoGenValidate/project/plugins.sbt
@@ -1,0 +1,2 @@
+resolvers += Resolver.sonatypeRepo("snapshots")
+addSbtPlugin("io.higherkindness" %% "sbt-mu-srcgen" % sys.props("version"))

--- a/plugin/src/sbt-test/sbt-mu-srcgen/srcProtoGenValidate/src/main/resources/person.proto
+++ b/plugin/src/sbt-test/sbt-mu-srcgen/srcProtoGenValidate/src/main/resources/person.proto
@@ -1,0 +1,23 @@
+syntax = "proto3";
+
+package com.proto;
+
+import "validate/validate.proto";
+
+message Person {
+  uint64 id    = 1 [(validate.rules).uint64.gt    = 999];
+
+  string email = 2 [(validate.rules).string.email = true];
+
+  string name  = 3 [(validate.rules).string = {
+                      pattern:   "^[^[0-9]A-Za-z]+( [^[0-9]A-Za-z]+)*$",
+                      max_bytes: 256,
+                   }];
+
+  Location home = 4 [(validate.rules).message.required = true];
+
+  message Location {
+    double lat = 1 [(validate.rules).double = { gte: -90,  lte: 90 }];
+    double lng = 2 [(validate.rules).double = { gte: -180, lte: 180 }];
+  }
+}

--- a/plugin/src/sbt-test/sbt-mu-srcgen/srcProtoGenValidate/test
+++ b/plugin/src/sbt-test/sbt-mu-srcgen/srcProtoGenValidate/test
@@ -1,0 +1,3 @@
+> +compile
+$ exists target/scala-2.13/src_managed/main/compiled_proto/com/proto/person/Person.scala
+$ exists target/scala-2.13/src_managed/main/compiled_proto/com/proto/person/PersonValidator.scala


### PR DESCRIPTION
Relates to https://github.com/higherkindness/sbt-mu-srcgen/issues/303

Introduces the scalapb-validate plugin to generate validation methods in the PB source generation

This is handled by a new setting key

Docs: https://github.com/higherkindness/sbt-mu-srcgen/pull/304