### PR TITLE
Fix the broken urls

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ auto-generate [mu-scala] code, like such:
 **This is a breaking change between the versions**, so be sure to make sure that you're choosing your modules to enable source generation
 intentionally if you want to upgrade this library.
 
-The full documentation is available at the [mu](https://higherkindness.io/mu-scala/guides/generate-sources-from-idl) site.
+The full documentation is available at the [mu](https://higherkindness.github.io/mu-scala/guides/generate-sources-from-idl) site.
 
 [RPC]: https://en.wikipedia.org/wiki/Remote_procedure_call
 [HTTP/2]: https://http2.github.io/

--- a/docs/README.md
+++ b/docs/README.md
@@ -32,7 +32,7 @@ auto-generate [mu-scala] code, like such:
 **This is a breaking change between the versions**, so be sure to make sure that you're choosing your modules to enable source generation
 intentionally if you want to upgrade this library.
 
-The full documentation is available at the [mu](https://higherkindness.io/mu-scala/guides/generate-sources-from-idl) site.
+The full documentation is available at the [mu](https://higherkindness.github.io/mu-scala/guides/generate-sources-from-idl) site.
 
 [RPC]: https://en.wikipedia.org/wiki/Remote_procedure_call
 [HTTP/2]: https://http2.github.io/


### PR DESCRIPTION
Solves issue #403 in the README.md files.

It does not solve the URL in the GitHub landing page, section `About`